### PR TITLE
Use x86-64 or ARM64 .dmgs for macOS, matching the runner arch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,12 @@ runs:
     - if: runner.os == 'macOS'
       shell: bash
       run: |
-        curl -L "https://download.pulsar-edit.dev/?os=intel_mac&type=mac_dmg" --output pulsar.dmg
+        DOWNLOAD_OS="silicon_mac"
+        if [ "${RUNNER_ARCH}" = "X64" ]; then
+          DOWNLOAD_OS="intel_mac"
+        fi
+
+        curl -L "https://download.pulsar-edit.dev/?os=${DOWNLOAD_OS}&type=mac_dmg" --output pulsar.dmg
         hdiutil attach pulsar.dmg
         sudo cp -rf /Volumes/Pulsar*/Pulsar.app /Applications
         sudo mkdir -p /usr/local/bin/


### PR DESCRIPTION
Should resolve #13 

Uses the optimally-performing, arch-appropriate .dmg when setting up for macOS.

Previously we just assumed x86-64 (intel), but the default macOS runners on GitHub Actions are now  ARM64 ("Apple Silicon")! The intel .dmgs are cross-compatible enough to run on ARM64 macOS runners, presumably via Rosetta, for now, but Rosetta may be deprecated or removed in a future version of macOS, so we shouldn't rely on it.

See the following documentation to verify that
these are the correct values for these variables:
- https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables
  - RUNNER_ARCH (X64 or ARM64)
- https://github.com/pulsar-edit/package-frontend/blob/main/docs/download_links.md
  - os (intel_mac or silicon_mac)